### PR TITLE
fixed prompt for longer command lines

### DIFF
--- a/notebook.zsh-theme
+++ b/notebook.zsh-theme
@@ -3,7 +3,7 @@
 local user_host='%{$terminfo[bold]$fg[green]%}%n%{$reset_color%}'
 local current_dir='%{$terminfo[bold]$fg[magenta]%}%~%{$reset_color%}'
 local hostname='%{$terminfo[bold]$fg[white]%}%m%{$reset_color%}'
-local point='%{$terminfo[bold]$fg[red]>>${reset_color%}'
+local point='%{$terminfo[bold]%}%{$fg[red]%}>>%{$reset_color%}'
 
 function prompt_char {
   if [ $UID -eq 0 ]; then echo "#"; else echo $; fi


### PR DESCRIPTION
This should solve problems occurring when the command is longer than the terminal width. After reaching the end of the line the inserted text used to overwrite the second line of the prompt and the command line itself. I had this problem on termite (a vte3 based terminal) and xterm.

P.S. thanks for the nice theme.